### PR TITLE
Fix `widelyAvailableOnDate` using the current system month instead of the provided month

### DIFF
--- a/src/scripts/baseline-browser-versions.ts
+++ b/src/scripts/baseline-browser-versions.ts
@@ -423,7 +423,7 @@ export function getCompatibleVersions(userOptions?: Options): BrowserVersion[] {
 
   // Sets a cutoff date for feature interoperability 30 months before the stated date
   if (options.widelyAvailableOnDate || options.targetYear === undefined) {
-    targetDate.setMonth(new Date().getMonth() - 30);
+    targetDate.setMonth(targetDate.getMonth() - 30);
   }
 
   let coreBrowserArray = getCoreVersionsByDate(


### PR DESCRIPTION
Fixes #22