### PR TITLE
Fixes for older versions of node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "baseline-browser-mapping",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "baseline-browser-mapping",
-      "version": "2.8.3",
+      "version": "2.8.4",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baseline-browser-mapping",
   "main": "./dist/index.cjs",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "description": "A library for obtaining browser versions with their maximum supported Baseline feature set and Widely Available status.",
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baseline-browser-mapping",
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "version": "2.8.3",
   "description": "A library for obtaining browser versions with their maximum supported Baseline feature set and Widely Available status.",
   "exports": {
@@ -14,6 +14,7 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "jsdelivr": "./dist/index.js",
   "files": [
     "dist/*",
     "!dist/scripts/*",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,6 +12,7 @@ export default [
       typescript({
         tsconfig: "./tsconfig.json",
         outDir: "dist",
+        target: "es2017",
       }),
       terser(),
     ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,7 +9,10 @@ export default [
       dir: "dist",
     },
     plugins: [
-      typescript({ tsconfig: "./tsconfig.json", outDir: "dist" }),
+      typescript({
+        tsconfig: "./tsconfig.json",
+        outDir: "dist",
+      }),
       terser(),
     ],
   },
@@ -20,7 +23,11 @@ export default [
       file: "dist/index.cjs",
     },
     plugins: [
-      typescript({ tsconfig: "./tsconfig.json", outDir: "dist" }),
+      typescript({
+        tsconfig: "./tsconfig.json",
+        outDir: "dist",
+        target: "es2017",
+      }),
       terser(),
     ],
   },


### PR DESCRIPTION
Now that `baseline-browser-mapping` is being used in `browserslist`, it is being used in many older versions of Node that don't support some of its syntax.  This PR changes the compilation output to target ES2017, knowing that the module is used mostly in toolchain environments and we don't want to break compatibility for users in older environments.