### PR TITLE
feat: add getTimeline() to expose core browser compatibility timelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,13 @@ If you want to ensure [reproducible builds](https://www.wikiwand.com/en/articles
 
 ## Importing `baseline-browser-mapping`
 
-This module exposes two functions: `getCompatibleVersions()` and `getAllVersions()`, both which can be imported directly from `baseline-browser-mapping`:
+This module exposes three functions: `getCompatibleVersions()`, `getAllVersions()`, and `getTimeline()`, all of which can be imported directly from `baseline-browser-mapping`:
 
 ```javascript
 import {
   getCompatibleVersions,
   getAllVersions,
+  getTimeline,
 } from "baseline-browser-mapping";
 ```
 
@@ -57,6 +58,7 @@ If you want to load the script and data directly in a web page without hosting i
   import {
     getCompatibleVersions,
     getAllVersions,
+    getTimeline,
   } from "https://cdn.jsdelivr.net/npm/baseline-browser-mapping";
 </script>
 ```
@@ -404,6 +406,35 @@ The outputs of `getAllVersions()` are available as JSON or CSV files generated o
   - [CSV](https://web-platform-dx.github.io/baseline-browser-mapping/with_downstream/all_versions_with_supports.csv)
 
 These files are updated on a daily basis.
+
+## Get timeline of browser version compatibility bumps
+
+To calculate compatible browser versions on custom/arbitrary dates completely client-side without loading the full `@mdn/browser-compat-data` database, you can call the `getTimeline()` function. It returns the timeline of minimum version requirements for each core browser:
+
+```javascript
+import { getTimeline } from "baseline-browser-mapping";
+
+const timeline = getTimeline();
+```
+
+It returns an `Object` with arrays of transition events for each core browser:
+
+```javascript
+{
+  chrome: [
+    { date: "2015-07-29", version: "44" },
+    { date: "2016-03-02", version: "49" },
+    ...
+  ],
+  safari: [
+    { date: "2015-09-30", version: "9" },
+    ...
+  ],
+  ...
+}
+```
+
+Whenever a new web platform feature becomes Baseline-low, if it requires a higher version than the current minimum required version of a core browser, a transition event is added to the timeline with the date the feature became Baseline-low and the new required version.
 
 ## CLI
 

--- a/spec/tests/index.browser.js
+++ b/spec/tests/index.browser.js
@@ -1,4 +1,8 @@
-import { getCompatibleVersions, getAllVersions } from "../../dist/index.js";
+import {
+  getCompatibleVersions,
+  getAllVersions,
+  getTimeline,
+} from "../../dist/index.js";
 
 describe("baseline-browser-mapping in browser", function () {
   it("should load getCompatibleVersions", function () {
@@ -7,6 +11,10 @@ describe("baseline-browser-mapping in browser", function () {
 
   it("should load getAllVersions", function () {
     expect(typeof getAllVersions).toBe("function");
+  });
+
+  it("should load getTimeline", function () {
+    expect(typeof getTimeline).toBe("function");
   });
 
   it("getCompatibleVersions should return an array", function () {
@@ -18,5 +26,12 @@ describe("baseline-browser-mapping in browser", function () {
     const versions = getAllVersions();
     expect(typeof versions).toBe("object");
     expect(versions).not.toBeNull();
+  });
+
+  it("getTimeline should return a timeline object", function () {
+    const timeline = getTimeline();
+    expect(typeof timeline).toBe("object");
+    expect(timeline).not.toBeNull();
+    expect(Array.isArray(timeline.chrome)).toBe(true);
   });
 });

--- a/spec/tests/index.node.js
+++ b/spec/tests/index.node.js
@@ -1,6 +1,7 @@
 import {
   getCompatibleVersions,
   getAllVersions,
+  getTimeline,
   _resetHasWarned,
 } from "baseline-browser-mapping";
 import fs from "fs";
@@ -148,5 +149,35 @@ describe("getAllVersions default", () => {
     expect(csvExportLines[1].startsWith('"chrome","0","pre_baseline"')).toBe(
       true,
     );
+  });
+});
+
+describe("getTimeline", () => {
+  it("Returns a timeline object with keys for core browsers", () => {
+    const timeline = getTimeline();
+    expect(timeline).toBeDefined();
+    expect(typeof timeline).toBe("object");
+    expect(Array.isArray(timeline.chrome)).toBe(true);
+    expect(Array.isArray(timeline.safari)).toBe(true);
+    expect(Array.isArray(timeline.firefox)).toBe(true);
+  });
+
+  it("Timeline entries are sorted by date and have version strings", () => {
+    const timeline = getTimeline();
+    const chromeTimeline = timeline.chrome;
+    expect(chromeTimeline.length).toBeGreaterThan(0);
+
+    // Check structure of first entry
+    expect(chromeTimeline[0].date).toBeDefined();
+    expect(chromeTimeline[0].version).toBeDefined();
+
+    // Verify chronological sorting and ascending versions
+    for (let i = 1; i < chromeTimeline.length; i++) {
+      const prev = chromeTimeline[i - 1];
+      const curr = chromeTimeline[i];
+
+      // Date should be equal or later
+      expect(curr.date >= prev.date).toBe(true);
+    }
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -831,3 +831,60 @@ export function getAllVersions(
 
   return outputArray;
 }
+
+export type TimelineEntry = {
+  date: string;
+  version: string;
+};
+
+export type Timeline = {
+  [browser: string]: TimelineEntry[];
+};
+
+/**
+ * Returns the timeline of minimum version changes for each core browser.
+ * Whenever a new feature becomes Baseline-low, if it increases the required version
+ * of a core browser, a new entry (date and version) is recorded in the timeline.
+ */
+export function getTimeline(): Timeline {
+  const timeline: Timeline = {};
+
+  bcdCoreBrowserNames.forEach((browser) => {
+    timeline[browser] = [];
+  });
+
+  const sortedFeatures = [...features]
+    .filter((f) => f.status.baseline_low_date)
+    .sort((a, b) => {
+      const dateA = stripLTEPrefix(a.status.baseline_low_date);
+      const dateB = stripLTEPrefix(b.status.baseline_low_date);
+      return dateA.localeCompare(dateB);
+    });
+
+  const currentMinVersions: { [browser: string]: string } = {};
+  bcdCoreBrowserNames.forEach((browser) => {
+    currentMinVersions[browser] = "0";
+  });
+
+  sortedFeatures.forEach((feature) => {
+    const date = stripLTEPrefix(feature.status.baseline_low_date);
+    Object.keys(feature.status.support).forEach((browser) => {
+      if (bcdCoreBrowserNames.includes(browser)) {
+        // @ts-ignore
+        const versionStr = feature.status.support[browser];
+        if (!versionStr) return;
+        const version = stripLTEPrefix(versionStr);
+        const currentVersion = currentMinVersions[browser] ?? "0";
+        if (compareVersions(version, currentVersion) === 1) {
+          currentMinVersions[browser] = version;
+          timeline[browser]!.push({
+            date: date,
+            version: version,
+          });
+        }
+      }
+    });
+  });
+
+  return timeline;
+}


### PR DESCRIPTION
## Description
Currently, downstream applications that consume data exported by this package cannot calculate compatibility for arbitrary custom dates offline or client-side. This is because the existing `getAllVersions()` function only provides data bucketed into yearly bins and static execution-date flags, losing the day-to-day progression of feature compatibility requirements. Because of this restriction, we cannot implement date-based baseline queries (e.g.  `baseline widely available on YYYY-MM-DD` ) in non-JS environments.

This PR introduces a new exported function `getTimeline()` to address this limitation. It returns the chronological timeline of when each core browser version became the minimum required version.

fixes #134.

## Changes
- **Core Implementation**: Added and exported `getTimeline()` in index.ts.
- **Tests & Docs**: Added comprehensive unit tests in index.node.js / index.browser.js and documented the usage in README.md.